### PR TITLE
Create host header from CupsClient configuration

### DIFF
--- a/src/main/java/org/cups4j/operations/IppHttp.java
+++ b/src/main/java/org/cups4j/operations/IppHttp.java
@@ -18,7 +18,6 @@ public final class IppHttp {
 	private static final int MAX_CONNECTION_BUFFER = 20;
 
 	private static final int CUPSTIMEOUT = Integer.parseInt(System.getProperty("cups4j.timeout", "10000"));
-	private static final String CUPSHOST = System.getProperty("cups4j.ourhostname", "localhost");
 
 	private static final RequestConfig requestConfig = RequestConfig.custom()
 			.setSocketTimeout(CUPSTIMEOUT).setConnectTimeout(CUPSTIMEOUT)
@@ -41,15 +40,13 @@ public final class IppHttp {
 	}
 
 	public static void setHttpHeaders(HttpPost httpPost, CupsPrinter targetPrinter,
-			CupsAuthentication creds) {
+			CupsAuthentication creds, String hostname, int port) {
 		 if (targetPrinter == null) {
 			 httpPost.addHeader("target-group", "local");
 		 } else {
 		 	 httpPost.addHeader("target-group", targetPrinter.getName());
 		 }
-		 if (CUPSHOST != null && !"".equals(CUPSHOST)) {
-	     httpPost.addHeader("Host", CUPSHOST);
-	   }
+		 httpPost.addHeader("Host", String.format("%s:%s", hostname, port));
 	   httpPost.setConfig(requestConfig);
 
 	   if (creds != null && StringUtils.isNotBlank(creds.getUserid())

--- a/src/main/java/org/cups4j/operations/IppOperation.java
+++ b/src/main/java/org/cups4j/operations/IppOperation.java
@@ -157,7 +157,7 @@ public abstract class IppOperation {
     CloseableHttpClient client = IppHttp.createHttpClient();
 	
     HttpPost httpPost = new HttpPost(new URI("http://" + url.getHost() + ":" + ippPort) + url.getPath());
-    IppHttp.setHttpHeaders(httpPost, printer, creds);
+    IppHttp.setHttpHeaders(httpPost, printer, creds, url.getHost(), ippPort);
 
     byte[] bytes = new byte[ippBuf.limit()];
     ippBuf.get(bytes);

--- a/src/main/java/org/cups4j/operations/ipp/IppCreateJobOperation.java
+++ b/src/main/java/org/cups4j/operations/ipp/IppCreateJobOperation.java
@@ -133,12 +133,12 @@ public class IppCreateJobOperation extends IppOperation {
         }
     }
 
-    private static IppResult sendRequest(CupsPrinter printer, URI uri, ByteBuffer ippBuf,
+    private IppResult sendRequest(CupsPrinter printer, URI uri, ByteBuffer ippBuf,
     		CupsAuthentication creds) throws IOException {
         CloseableHttpClient client = IppHttp.createHttpClient();
 
         HttpPost httpPost = new HttpPost(uri);
-        IppHttp.setHttpHeaders(httpPost, printer, creds);
+        IppHttp.setHttpHeaders(httpPost, printer, creds, uri.getHost(), ippPort);
 
         byte[] bytes = new byte[ippBuf.limit()];
         ippBuf.get(bytes);

--- a/src/main/java/org/cups4j/operations/ipp/IppSendDocumentOperation.java
+++ b/src/main/java/org/cups4j/operations/ipp/IppSendDocumentOperation.java
@@ -272,7 +272,7 @@ public class IppSendDocumentOperation extends IppPrintJobOperation {
         InputStreamEntity requestEntity = new InputStreamEntity(inputStream, -1);
         requestEntity.setContentType(IPP_MIME_TYPE);
         httpPost.setEntity(requestEntity);
-        IppHttp.setHttpHeaders(httpPost, printer, creds);
+        IppHttp.setHttpHeaders(httpPost, printer, creds, uri.getHost(), ippPort);
 
         CloseableHttpClient client = HttpClients.custom().build();
         try {


### PR DESCRIPTION
Hi!

For the current version, to work with a CUPS server that it's not in localhost, you need to add a property cups.ourhostname.

If you look in this link:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host

The Host header is the hostname + port for the destination host, in this case the CUPS server.

We already have the hostname and the port configured in the CupsClient creation, so I think we don't need and additional property to configure this. 

Thanks!