### PR TITLE
[master]: Apache HttpClient will set Host header automatically

### DIFF
--- a/src/main/java/org/cups4j/operations/IppHttp.java
+++ b/src/main/java/org/cups4j/operations/IppHttp.java
@@ -18,7 +18,6 @@ public final class IppHttp {
 	private static final int MAX_CONNECTION_BUFFER = 20;
 
 	private static final int CUPSTIMEOUT = Integer.parseInt(System.getProperty("cups4j.timeout", "10000"));
-	private static final String CUPSHOST = System.getProperty("cups4j.ourhostname", "localhost");
 
 	private static final RequestConfig requestConfig = RequestConfig.custom()
 			.setSocketTimeout(CUPSTIMEOUT).setConnectTimeout(CUPSTIMEOUT)
@@ -47,9 +46,6 @@ public final class IppHttp {
 		 } else {
 		 	 httpPost.addHeader("target-group", targetPrinter.getName());
 		 }
-		 if (CUPSHOST != null && !"".equals(CUPSHOST)) {
-	     httpPost.addHeader("Host", CUPSHOST);
-	   }
 	   httpPost.setConfig(requestConfig);
 
 	   if (creds != null && StringUtils.isNotBlank(creds.getUserid())


### PR DESCRIPTION
The intention of this change is to remove the configurable host header via properties. After removing this Apache HttpClient will calculate this header automatically. I have tested this enabling Apache HttpClient logs with this result:

2020/11/19 08:46:40:487 CET [DEBUG] headers - http-outgoing-0 >> Content-Type: application/ipp
2020/11/19 08:46:40:487 CET [DEBUG] headers - http-outgoing-0 >> Host: localhost:631
2020/11/19 08:46:40:487 CET [DEBUG] headers - http-outgoing-0 >> Connection: Keep-Alive

Thanks!