### PR TITLE
Replace simple-xml with JAXB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.simpleframework</groupId>
-      <artifactId>simple-xml</artifactId>
-      <version>2.7.1</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.13</version>
@@ -81,6 +75,12 @@
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/ch/ethz/vppserver/ippclient/IIppAttributeProvider.java
+++ b/src/main/java/ch/ethz/vppserver/ippclient/IIppAttributeProvider.java
@@ -14,17 +14,18 @@ package ch.ethz.vppserver.ippclient;
  * the GNU Lesser General Public License along with this program; if not, see
  * <http://www.gnu.org/licenses/>.
  */
-import java.util.List;
 
 import org.cups4j.ipp.attributes.AttributeGroup;
 import org.cups4j.ipp.attributes.Tag;
 
+import java.util.List;
+
 public interface IIppAttributeProvider {
-  public final static String TAG_LIST_FILENAME = "config/ippclient/ipp-list-of-tag.xml";
-  public final static String ATTRIBUTE_LIST_FILENAME = "config/ippclient/ipp-list-of-attributes.xml";
-  public final static String CONTEXT = "ch.ethz.vppserver.schema.ippclient";
+  String TAG_LIST_FILENAME = "config/ippclient/ipp-list-of-tag.xml";
+  String ATTRIBUTE_LIST_FILENAME = "config/ippclient/ipp-list-of-attributes.xml";
+  String CONTEXT = "ch.ethz.vppserver.schema.ippclient";
 
-  public List<Tag> getTagList();
+  List<Tag> getTagList();
 
-  public List<AttributeGroup> getAttributeGroupList();
+  List<AttributeGroup> getAttributeGroupList();
 }

--- a/src/main/java/org/cups4j/ipp/attributes/Attribute.java
+++ b/src/main/java/org/cups4j/ipp/attributes/Attribute.java
@@ -7,20 +7,20 @@
 
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 
-@Root(name = "attribute")
+@XmlType(name = "attribute")
 public class Attribute {
 
-  @ElementList(entry = "attribute-value", inline = true)
+  @XmlElement(name ="attribute-value")
   protected List<AttributeValue> attributeValue;
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String name;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**
@@ -48,7 +48,7 @@ public class Attribute {
    */
   public List<AttributeValue> getAttributeValue() {
     if (attributeValue == null) {
-      attributeValue = new ArrayList<AttributeValue>();
+      attributeValue = new ArrayList<>();
     }
     return this.attributeValue;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/AttributeGroup.java
+++ b/src/main/java/org/cups4j/ipp/attributes/AttributeGroup.java
@@ -7,21 +7,21 @@
 
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 
-@Root(name = "attribute-group")
+@XmlType(name = "attribute-group")
 public class AttributeGroup {
-  @ElementList(entry = "attribute", inline = true)
+  @XmlElement(name ="attribute")
   protected List<Attribute> attribute;
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String tag;
-  @org.simpleframework.xml.Attribute(name = "tag-name", required = true)
+  @XmlAttribute(name = "tag-name", required = true)
   protected String tagName;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**
@@ -48,7 +48,7 @@ public class AttributeGroup {
    */
   public List<Attribute> getAttribute() {
     if (attribute == null) {
-      attribute = new ArrayList<Attribute>();
+      attribute = new ArrayList<>();
     }
     return this.attribute;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/AttributeList.java
+++ b/src/main/java/org/cups4j/ipp/attributes/AttributeList.java
@@ -7,24 +7,33 @@
 
 package org.cups4j.ipp.attributes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.simpleframework.xml.Attribute;
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
-@Root(name = "attribute-list")
+@XmlRootElement(name = "attribute-list")
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class AttributeList {
-  @Attribute
+  
   protected String schemaLocation;
-
-  @ElementList(entry = "attribute-group", inline = true, required = true)
+  
   protected List<AttributeGroup> attributeGroup;
-
-  @org.simpleframework.xml.Attribute(required = false)
+  
   protected String description;
-
+  
+  @XmlAttribute
+  public String getSchemaLocation() {
+    return schemaLocation;
+  }
+  
+  public void setSchemaLocation(String schemaLocation) {
+    this.schemaLocation = schemaLocation;
+  }
+  
   /**
    * Gets the value of the attributeGroup property.
    * 
@@ -48,19 +57,25 @@ public class AttributeList {
    * 
    * 
    */
+  @XmlElement(name = "attribute-group")
   public List<AttributeGroup> getAttributeGroup() {
     if (attributeGroup == null) {
-      attributeGroup = new ArrayList<AttributeGroup>();
+      attributeGroup = new ArrayList<>();
     }
     return this.attributeGroup;
   }
-
+  
+  public void setAttributeGroup(List<AttributeGroup> attributeGroup) {
+    this.attributeGroup = attributeGroup;
+  }
+  
   /**
    * Gets the value of the description property.
    * 
    * @return possible object is {@link String }
    * 
    */
+  @XmlAttribute
   public String getDescription() {
     return description;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/AttributeValue.java
+++ b/src/main/java/org/cups4j/ipp/attributes/AttributeValue.java
@@ -7,23 +7,24 @@
 
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.Element;
-import org.simpleframework.xml.Root;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
-@Root(name = "attribute-value")
+@XmlType(name = "attribute-value")
 public class AttributeValue {
 
-  @Element(name = "set-of-keyword", required = false)
+  @XmlElement(name = "set-of-keyword")
   protected SetOfKeyword setOfKeyword;
-  @Element(name = "set-of-enum", required = false)
+  @XmlElement(name = "set-of-enum")
   protected SetOfEnum setOfEnum;
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String tag;
-  @org.simpleframework.xml.Attribute(name = "tag-name", required = true)
+  @XmlAttribute(name = "tag-name", required = true)
   protected String tagName;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String value;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**

--- a/src/main/java/org/cups4j/ipp/attributes/Enum.java
+++ b/src/main/java/org/cups4j/ipp/attributes/Enum.java
@@ -7,16 +7,17 @@
 
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.Root;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
 
-@Root(name = "enum")
+@XmlType(name = "enum")
 public class Enum {
 
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String name;
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String value;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**

--- a/src/main/java/org/cups4j/ipp/attributes/Keyword.java
+++ b/src/main/java/org/cups4j/ipp/attributes/Keyword.java
@@ -7,14 +7,15 @@
 
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.Root;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
 
-@Root(name = "keyword")
+@XmlType(name = "keyword")
 public class Keyword {
 
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String value;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**

--- a/src/main/java/org/cups4j/ipp/attributes/SetOfEnum.java
+++ b/src/main/java/org/cups4j/ipp/attributes/SetOfEnum.java
@@ -7,18 +7,18 @@
 
 package org.cups4j.ipp.attributes;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
-@Root(name = "set-of-enum")
+@XmlType(name = "set-of-enum")
 public class SetOfEnum {
 
-  @ElementList(entry = "enum", inline = true)
+  @XmlElement(name ="enum")
   protected List<Enum> _enum;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
 
   /**
@@ -45,7 +45,7 @@ public class SetOfEnum {
    */
   public List<Enum> getEnum() {
     if (_enum == null) {
-      _enum = new ArrayList<Enum>();
+      _enum = new ArrayList<>();
     }
     return this._enum;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/SetOfKeyword.java
+++ b/src/main/java/org/cups4j/ipp/attributes/SetOfKeyword.java
@@ -7,17 +7,20 @@
 
 package org.cups4j.ipp.attributes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
-@Root(name = "set-of-keyword")
+@XmlType(name = "set-of-keyword")
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class SetOfKeyword {
-  @ElementList(entry = "keyword", inline = true)
+  
   protected List<Keyword> keyword;
-  @org.simpleframework.xml.Attribute(required = false)
+
   protected String description;
 
   /**
@@ -42,9 +45,10 @@ public class SetOfKeyword {
    * 
    * 
    */
+  @XmlElement(name ="keyword")
   public List<Keyword> getKeyword() {
     if (keyword == null) {
-      keyword = new ArrayList<Keyword>();
+      keyword = new ArrayList<>();
     }
     return this.keyword;
   }
@@ -55,6 +59,7 @@ public class SetOfKeyword {
    * @return possible object is {@link String }
    * 
    */
+  @XmlAttribute
   public String getDescription() {
     return description;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/Tag.java
+++ b/src/main/java/org/cups4j/ipp/attributes/Tag.java
@@ -1,17 +1,18 @@
 package org.cups4j.ipp.attributes;
 
-import org.simpleframework.xml.Root;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
 
-@Root(name = "tag")
+@XmlType(name = "tag")
 public class Tag {
 
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String value;
-  @org.simpleframework.xml.Attribute(required = true)
+  @XmlAttribute(required = true)
   protected String name;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected String description;
-  @org.simpleframework.xml.Attribute(required = false)
+  @XmlAttribute
   protected Short max;
 
   /**
@@ -97,5 +98,5 @@ public class Tag {
   public void setMax(Short value) {
     this.max = value;
   }
-
+  
 }

--- a/src/main/java/org/cups4j/ipp/attributes/TagList.java
+++ b/src/main/java/org/cups4j/ipp/attributes/TagList.java
@@ -1,30 +1,50 @@
 package org.cups4j.ipp.attributes;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.simpleframework.xml.Attribute;
-import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Root;
-
-@Root(name = "tag-list")
+@XmlRootElement(name = "tag-list")
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class TagList {
-  @Attribute
+  
   protected String schemaLocation;
-  @ElementList(entry = "tag", inline = true, required = true)
+  
   protected List<Tag> tag;
-
+  
+  /**
+   * @return list of tags
+   */
+  @XmlElement(name = "tag", required = true)
   public List<Tag> getTag() {
     if (tag == null) {
-      tag = new ArrayList<Tag>();
+      tag = new ArrayList<>();
     }
-    return this.tag;
+    return tag;
   }
-
+  
+  /**
+   * @param tag list of tags to set
+   */
+  public void setTag(List<Tag> tag) {
+    this.tag = tag;
+  }
+  
+  /**
+   * @return schema location
+   */
+  @XmlAttribute
   public String getSchemaLocation() {
     return schemaLocation;
   }
-
+  
+  /**
+   * @param schemaLocation the schema location to set
+   */
   public void setSchemaLocation(String schemaLocation) {
     this.schemaLocation = schemaLocation;
   }

--- a/src/main/java/org/cups4j/ipp/attributes/package-info.java
+++ b/src/main/java/org/cups4j/ipp/attributes/package-info.java
@@ -1,0 +1,11 @@
+@XmlSchema(namespace = "http://www.vppserver.ethz.ch/schema/ippclient", elementFormDefault = XmlNsForm.QUALIFIED,
+		xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.vppserver.ethz.ch/schema/ippclient")}
+)
+@XmlAccessorType(XmlAccessType.FIELD)
+package org.cups4j.ipp.attributes;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/src/test/java/org/cups4j/ipp/attributes/IppAttributeProviderTest.java
+++ b/src/test/java/org/cups4j/ipp/attributes/IppAttributeProviderTest.java
@@ -1,0 +1,64 @@
+package org.cups4j.ipp.attributes;
+
+import ch.ethz.vppserver.ippclient.IppAttributeProvider;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class IppAttributeProviderTest {
+	
+	@Test
+	public void testAttributeGroups() {
+		List<AttributeGroup> attributeGroups = IppAttributeProvider.getInstance().getAttributeGroupList();
+		assertEquals(5, attributeGroups.size());
+		for (AttributeGroup attributeGroup : attributeGroups) {
+			testAttributeGroup(attributeGroup);
+		}
+	}
+	
+	private void testAttributeGroup(AttributeGroup group) {
+		assertNotNull(group.getTag());
+		assertFalse(group.getTag().isEmpty());
+		assertNotNull(group.getTagName());
+		assertFalse(group.getTagName().isEmpty());
+		
+		for (Attribute attribute : group.getAttribute()) {
+			testAttribute(attribute);
+		}
+	}
+	
+	private void testAttribute(Attribute attribute) {
+		assertNotNull(attribute.getName());
+		
+		for (AttributeValue attributeValue : attribute.getAttributeValue()) {
+			assertNotNull(attributeValue.getTag());
+			assertFalse(attributeValue.getTag().isEmpty());
+			assertNotNull(attributeValue.getTagName());
+			assertFalse(attributeValue.getTagName().isEmpty());
+			
+			SetOfKeyword setOfKeyword = attributeValue.getSetOfKeyword();
+			if (setOfKeyword != null) {
+				for (Keyword keyword : setOfKeyword.getKeyword()) {
+					assertNotNull(keyword.getValue());
+					assertFalse(keyword.getValue().isEmpty());
+				}
+			}
+		}
+	}
+	
+	@Test
+	public void testTagList() {
+		List<Tag> tagList = IppAttributeProvider.getInstance().getTagList();
+		assertEquals(37, tagList.size());
+		for (Tag tag : tagList) {
+			assertNotNull(tag.getName());
+			assertFalse(tag.getName().isEmpty());
+			assertNotNull(tag.getValue());
+			assertFalse(tag.getValue().isEmpty());
+		}
+	}
+}


### PR DESCRIPTION
Use JAXB for unmarshalling XML resources in order to replace the unmaintained "simple-xml" dependency with vulnerability mentioned in #30