### PR TITLE
Bug-fix response attributes with tag no-value (0x13)

### DIFF
--- a/src/main/java/ch/ethz/vppserver/ippclient/IppResponse.java
+++ b/src/main/java/ch/ethz/vppserver/ippclient/IppResponse.java
@@ -577,6 +577,10 @@ public class IppResponse {
     if ((length != 0) && (_buf.remaining() >= length)) {
       setAttributeName(length);
     }
+    
+    // skip 2 Bytes (short value) of attribute value length (0x0000) in buffer 
+    if (_buf.remaining() >= 2)
+    	_buf.position(_buf.position() + 2);
   }
 
   /**


### PR DESCRIPTION
As described in RFC2910 Chapter 3.8 for "out-of-band" "value-tag" fields ..., such as "unsupported" (or "no-value"), the "value-length" MUST be 0 and the "value" empty.
Means there are still the 2 bytes of the value-length (0x0000) which has to be skipped instead of interpreting as a new AttributeGroup.