### PR TITLE
Fix IPP response text decoding using attributes-charset

### DIFF
--- a/src/main/java/ch/ethz/vppserver/ippclient/IppResponse.java
+++ b/src/main/java/ch/ethz/vppserver/ippclient/IppResponse.java
@@ -3,6 +3,10 @@ package ch.ethz.vppserver.ippclient;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,6 +48,7 @@ public class IppResponse {
   private AttributeGroup _attributeGroupResult = null;
   private Attribute _attributeResult = null;
   private List<AttributeGroup> _result = null;
+  private Charset _responseCharset = StandardCharsets.UTF_8;
 
   private static IIppAttributeProvider ippAttributeProvider = null;
 
@@ -77,6 +82,7 @@ public class IppResponse {
     _attributeGroupResult = null;
     _attributeResult = null;
     _result.clear();
+    _responseCharset = StandardCharsets.UTF_8;
 
     IppResult result = new IppResult();
     boolean httpResponse = false;
@@ -135,6 +141,7 @@ public class IppResponse {
     _attributeGroupResult = null;
     _attributeResult = null;
     _result.clear();
+    _responseCharset = StandardCharsets.UTF_8;
 
     IppResult result = new IppResult();
     boolean ippHeaderResponse = false;
@@ -229,7 +236,7 @@ public class IppResponse {
     IppResult result = new IppResult();
     byte[] buffer = new byte[_buf.capacity() - _buf.position()];
     _buf.get(buffer);
-    String errorText = new String(buffer);
+    String errorText = new String(buffer, StandardCharsets.UTF_8);
     if (errorText.contains("Unauthorized")) {
       result.setIppStatusResponse("client-error-not-authorized (0x403)");
     } else {
@@ -388,7 +395,8 @@ public class IppResponse {
     if ((length != 0) && (_buf.remaining() >= length)) {
       byte[] dst = new byte[length];
       _buf.get(dst);
-      String value = IppUtil.toString(dst);
+      String value = IppUtil.toString(dst, _responseCharset);
+      updateResponseCharset(value);
       String hex = IppUtil.toHexWithMarker(tag);
       AttributeValue attrValue = new AttributeValue();
       attrValue.setTag(hex);
@@ -421,7 +429,7 @@ public class IppResponse {
     if ((length != 0) && (_buf.remaining() >= length)) {
       byte[] dst = new byte[length];
       _buf.get(dst);
-      String value = IppUtil.toString(dst);
+      String value = IppUtil.toString(dst, _responseCharset);
       String hex = IppUtil.toHexWithMarker(tag);
       AttributeValue attrValue = new AttributeValue();
       attrValue.setTag(hex);
@@ -435,7 +443,7 @@ public class IppResponse {
       if ((length != 0) && (_buf.remaining() >= length)) {
         dst = new byte[length];
         _buf.get(dst);
-        value = IppUtil.toString(dst);
+        value = IppUtil.toString(dst, _responseCharset);
         attrValue = new AttributeValue();
         attrValue.setValue(value);
         _attributeResult.getAttributeValue().add(attrValue);
@@ -464,7 +472,7 @@ public class IppResponse {
     if ((length != 0) && (_buf.remaining() >= length)) {
       byte[] dst = new byte[length];
       _buf.get(dst);
-      String value = IppUtil.toString(dst);
+      String value = IppUtil.toString(dst, _responseCharset);
       String hex = IppUtil.toHexWithMarker(tag);
       AttributeValue attrValue = new AttributeValue();
       attrValue.setTag(hex);
@@ -478,7 +486,7 @@ public class IppResponse {
       if ((length != 0) && (_buf.remaining() >= length)) {
         dst = new byte[length];
         _buf.get(dst);
-        value = IppUtil.toString(dst);
+        value = IppUtil.toString(dst, _responseCharset);
         attrValue = new AttributeValue();
         attrValue.setValue(value);
         _attributeResult.getAttributeValue().add(attrValue);
@@ -686,12 +694,32 @@ public class IppResponse {
     }
     byte[] dst = new byte[length];
     _buf.get(dst);
-    String name = IppUtil.toString(dst);
+    String name = IppUtil.toString(dst, StandardCharsets.US_ASCII);
     if (_attributeResult != null) {
       _attributeGroupResult.getAttribute().add(_attributeResult);
     }
     _attributeResult = new Attribute();
     _attributeResult.setName(name.toString());
+  }
+
+  private void updateResponseCharset(String value) {
+    if ((_attributeResult == null) || (value == null)) {
+      return;
+    }
+    if (!"attributes-charset".equals(_attributeResult.getName())) {
+      return;
+    }
+
+    String charsetName = value.trim();
+    if (charsetName.isEmpty()) {
+      return;
+    }
+
+    try {
+      _responseCharset = Charset.forName(charsetName);
+    } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
+      LOG.warn("Unsupported IPP attributes-charset '{}', using {}", charsetName, _responseCharset.name());
+    }
   }
 
   /**

--- a/src/main/java/ch/ethz/vppserver/ippclient/IppUtil.java
+++ b/src/main/java/ch/ethz/vppserver/ippclient/IppUtil.java
@@ -5,6 +5,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
@@ -30,7 +31,7 @@ import java.util.ArrayList;
  */
 public class IppUtil {
 
-  private final static String DEFAULT_CHARSET = "UTF-8";
+  private final static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;;
 
   /**
    * 
@@ -74,30 +75,37 @@ public class IppUtil {
    * @return String representation
    */
   static String toString(byte[] dst) {
-    int l = dst.length;
-    StringBuilder sb = new StringBuilder(l);
-    for (int i = 0; i < l; i++) {
-      int b = dst[i];
-      int ival = ((int) b) & 0xff;
-      char c = (char) ival;
-      sb.append(c);
-    }
-    return sb.toString();
+    return toString(dst, StandardCharsets.UTF_8);
   }
 
   /**
-   * 
+   *
+   * @param dst
+   *          array of byte
+   * @param charset
+   *          charset used to decode the bytes
+   * @return String representation
+   */
+  static String toString(byte[] dst, Charset charset) {
+    if (charset == null) {
+      charset = DEFAULT_CHARSET;
+    }
+    return new String(dst, charset);
+  }
+
+  /**
+   *
    * @param str
    *          String to encode
-   * @param encoding
+   * @param charset
    * @return byte array
    * @throws UnsupportedEncodingException
    */
-  static public byte[] toBytes(String str, String encoding) throws UnsupportedEncodingException {
-    if (encoding == null) {
-      encoding = DEFAULT_CHARSET;
+  static public byte[] toBytes(String str, Charset charset) throws UnsupportedEncodingException {
+    if (charset == null) {
+      charset = DEFAULT_CHARSET;
     }
-    return str.getBytes(encoding);
+    return str.getBytes(charset);
   }
 
   /**
@@ -184,15 +192,14 @@ public class IppUtil {
   /**
    * 
    * @param str
-   * @param charsetName
+   * @param charset
    * @return
    * @throws CharacterCodingException
    */
-  static public String getTranslatedString(String str, String charsetName) throws CharacterCodingException {
-    if (charsetName == null) {
-      charsetName = DEFAULT_CHARSET;
+  static public String getTranslatedString(String str, Charset charset) throws CharacterCodingException {
+    if (charset == null) {
+      charset = DEFAULT_CHARSET;
     }
-    Charset charset = Charset.forName(charsetName);
     CharsetDecoder decoder = charset.newDecoder();
     CharsetEncoder encoder = charset.newEncoder();
     decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);

--- a/src/test/java/ch/ethz/vppserver/ippclient/IppResponseTest.java
+++ b/src/test/java/ch/ethz/vppserver/ippclient/IppResponseTest.java
@@ -4,9 +4,13 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.cups4j.ipp.attributes.Attribute;
@@ -47,9 +51,53 @@ public class IppResponseTest {
         assertThat(ippResult.getIppStatusResponse(), containsString("client-error-"));
     }
 
+    @Test
+    public void testGetResponseDecodesUtf8TextAttributes() throws IOException {
+        IppResult ippResult = ippResponse.getResponse(createIppResponse("utf-8", "打印机就绪", StandardCharsets.UTF_8));
+        AttributeGroup attributeGroup = ippResult.getAttributeGroup("operation-attributes-tag");
+        Attribute attr = attributeGroup.getAttribute("status-message");
+        assertEquals("打印机就绪", attr.getAttributeValue().get(0).getValue());
+    }
+
+    @Test
+    public void testGetResponseUsesDeclaredAttributesCharset() throws IOException {
+        Charset latin1 = Charset.forName("ISO-8859-1");
+        IppResult ippResult = ippResponse.getResponse(createIppResponse("iso-8859-1", "Jörg", latin1));
+        AttributeGroup attributeGroup = ippResult.getAttributeGroup("operation-attributes-tag");
+        Attribute attr = attributeGroup.getAttribute("status-message");
+        assertEquals("Jörg", attr.getAttributeValue().get(0).getValue());
+    }
+
     private IppResult readIppResponse(String filename) throws IOException {
         byte[] data = FileUtils.readFileToByteArray(new File("src/test/resources/ipp", filename));
         return ippResponse.getResponse(ByteBuffer.wrap(data));
+    }
+
+    private ByteBuffer createIppResponse(String charsetName, String message, Charset messageCharset) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bytes);
+        out.writeByte(0x01);
+        out.writeByte(0x01);
+        out.writeShort(0x0000);
+        out.writeInt(1);
+        out.writeByte(0x01);
+        writeTextAttribute(out, 0x47, "attributes-charset", charsetName, StandardCharsets.US_ASCII);
+        writeTextAttribute(out, 0x48, "attributes-natural-language", "zh-cn", StandardCharsets.US_ASCII);
+        writeTextAttribute(out, 0x41, "status-message", message, messageCharset);
+        out.writeByte(0x03);
+        out.flush();
+        return ByteBuffer.wrap(bytes.toByteArray());
+    }
+
+    private void writeTextAttribute(DataOutputStream out, int tag, String name, String value, Charset charset)
+            throws IOException {
+        byte[] nameBytes = name.getBytes(StandardCharsets.US_ASCII);
+        byte[] valueBytes = value.getBytes(charset);
+        out.writeByte(tag);
+        out.writeShort(nameBytes.length);
+        out.write(nameBytes);
+        out.writeShort(valueBytes.length);
+        out.write(valueBytes);
     }
 
 }


### PR DESCRIPTION
  Previously, text attributes were parsed through getAttributeGroupList(), but the underlying byte-to-string conversion did not actually decode bytes using the
  charset declared by the IPP response. It effectively treated each byte as a standalone character, which breaks non-ASCII content and can produce mojibake for
  fields such as status-message, job-name, and other human-readable text attributes.

  Changes in this PR:

  - Replace the byte-to-string conversion in IppUtil with proper Charset-based decoding.
  - Track attributes-charset in IppResponse and use it to decode subsequent text-based attribute values.
  - Keep attribute names decoded as ASCII, since IPP attribute names are protocol keywords rather than localized text.

  Tests added:

  - UTF-8 decoding for text attributes containing Chinese characters
  - Decoding using the response-declared charset (iso-8859-1)

  Validation:

  mvn -q -o -Dmaven.repo.local=/tmp/codex-m2 -Dtest=ch.ethz.vppserver.ippclient.IppResponseTest test